### PR TITLE
feat: newlines and braces for at-rules 

### DIFF
--- a/rules/core.js
+++ b/rules/core.js
@@ -21,6 +21,16 @@ module.exports = {
     // https://www.npmjs.com/package/stylelint-config-rational-order
     'plugin/rational-order': true,
 
+    // Require or disallow an empty line before at-rules.
+    // https://stylelint.io/user-guide/rules/at-rule-empty-line-before
+    'at-rule-empty-line-before': ['always', {
+      ignore: [
+        'after-comment',
+        'first-nested',
+        'blockless-after-same-name-blockless',
+      ],
+    }],
+
     // Require or disallow an empty line before the closing brace of blocks.
     // https://stylelint.io/user-guide/rules/block-closing-brace-empty-line-before
     'block-closing-brace-empty-line-before': null,

--- a/rules/sass.js
+++ b/rules/sass.js
@@ -4,5 +4,29 @@ module.exports = {
     // Specify blacklist of disallowed file extensions for partial names in @import commands.
     // https://github.com/kristerkari/stylelint-scss/blob/master/src/rules/at-import-partial-extension-blacklist/README.md
     'scss/at-import-partial-extension-blacklist': null,
+
+    // Require or disallow an empty line before at-rules.
+    // https://stylelint.io/user-guide/rules/at-rule-empty-line-before
+    'at-rule-empty-line-before': ['always', {
+      ignore: [
+        'after-comment',
+        'first-nested',
+        'blockless-after-same-name-blockless',
+      ],
+      ignoreAtRules: [
+        'else if',
+        'else',
+      ],
+    }],
+
+    // Require a newline or disallow whitespace after the closing brace of blocks.
+    // https://stylelint.io/user-guide/rules/block-closing-brace-newline-after
+    'block-closing-brace-newline-after': ['always', {
+      ignoreAtRules: [
+        'if',
+        'else if',
+        'else',
+      ],
+    }],
   },
 };


### PR DESCRIPTION
Add 2 new rulesets to handle newlines and braces around at-rules. Working currently with the core and sass configuration results in code layouts like this:

```css
.selector {

  @include foo();

  @apply mx;
  @apply py;
}
```

```css
.selector {
  @if ($bg != 0) {
    background-color: $bg;
  } 

  @else {
    background: #ff00ff;
  }
}
```

they are still valid but with this change it's also allowed to write code as

```css
.selector {
  @include foo();

  @apply mx;
  @apply py;
}
```

```css
.selector {
  @if ($bg != 0) {
    background-color: $bg;
  } @else {
    background: #ff00ff;
  }
}
```

**Note**
This one should be merged into the `feat/rules-setup` branch.