### PR TITLE
fix(sass): braces and newlines around at-rules

### DIFF
--- a/rules/sass.js
+++ b/rules/sass.js
@@ -1,6 +1,14 @@
 module.exports = {
   plugins: ['stylelint-scss'],
   rules: {
+    // Disallow unknown at-rules in favour of scss/at-rule-no-unknown.
+    // https://stylelint.io/user-guide/rules/at-rule-no-unknown
+    'at-rule-no-unknown': null,
+
+    // Disallow unknown at-rules in sass files.
+    // https://github.com/kristerkari/stylelint-scss/tree/master/src/rules/at-rule-no-unknown
+    'scss/at-rule-no-unknown': true,
+
     // Specify blacklist of disallowed file extensions for partial names in @import commands.
     // https://github.com/kristerkari/stylelint-scss/blob/master/src/rules/at-import-partial-extension-blacklist/README.md
     'scss/at-import-partial-extension-blacklist': null,
@@ -8,14 +16,19 @@ module.exports = {
     // Require or disallow an empty line before at-rules.
     // https://stylelint.io/user-guide/rules/at-rule-empty-line-before
     'at-rule-empty-line-before': ['always', {
+      except: [
+        'blockless-after-same-name-blockless',
+        'blockless-after-blockless',
+        'first-nested',
+      ],
       ignore: [
         'after-comment',
-        'first-nested',
-        'blockless-after-same-name-blockless',
       ],
       ignoreAtRules: [
+        'if',
         'else if',
         'else',
+        'return',
       ],
     }],
 

--- a/rules/tailwind.js
+++ b/rules/tailwind.js
@@ -1,6 +1,6 @@
 module.exports = {
   rules: {
-    // Disallow unknown at-rules.
+    // Disallow unknown at-rules in favour of scss/at-rule-no-unknown.
     // https://stylelint.io/user-guide/rules/at-rule-no-unknown
     'at-rule-no-unknown': null,
 
@@ -15,10 +15,6 @@ module.exports = {
           'responsive',
           'variants',
           'screen',
-          'extend',
-          'include',
-          'mixin',
-          'function',
         ],
       },
     ],


### PR DESCRIPTION
Fix miss-configured newlines around at-rules which caused incorrect errors. Now valid:

```css
@mixin foo() {
  //...
}

@mixin bar() {
  //...
}
```

```css
@function baz() {
  @return 42;
}
```

```css
@each $item in items {
  @if ($item == null) {
    background: red;
  } @else {
    background: map-get($item, 'background');
  }
}
```