### PR TITLE
fix(styled-components): circular extends

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "stylelint-config-rational-order": "^0.1.2",
     "stylelint-config-standard": "^21.0.0",
+    "stylelint-config-styled-components": "^0.1.1",
     "stylelint-order": "^4.1.0",
     "stylelint-processor-styled-components": "^1.10.0",
     "stylelint-scss": "^3.18.0"

--- a/rules/styled-components.js
+++ b/rules/styled-components.js
@@ -1,6 +1,4 @@
 module.exports = {
+  extends: ['stylelint-config-styled-components'],
   processors: ['stylelint-processor-styled-components'],
-  extends: [
-    '@edenspiekermann/stylelint-config/rules/styled-components',
-  ],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5090,6 +5090,11 @@ stylelint-config-standard@^21.0.0:
   dependencies:
     stylelint-config-recommended "^4.0.0"
 
+stylelint-config-styled-components@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/stylelint-config-styled-components/-/stylelint-config-styled-components-0.1.1.tgz#b408388d7c687833ab4be4c4e6522d97d2827ede"
+  integrity sha512-z5Xz/9GmvxO6e/DLzBMwkB85zHxEEjN6K7Cj80Bi+o/9vR9eS3GX3E9VuMnX9WLFYulqbqLtTapGGY28JBiy9Q==
+
 stylelint-order@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/stylelint-order/-/stylelint-order-2.2.1.tgz#cd2d4a0d81d91c705f1d275a58487e5ad5aa5828"


### PR DESCRIPTION
This fixes the circular self-extends of `@edenspiekermann/stylelint-config/rules/styled-components` for styled-components.